### PR TITLE
fix: use bridging urlParam to handle redirect

### DIFF
--- a/.yarn/versions/1d244ba3.yml
+++ b/.yarn/versions/1d244ba3.yml
@@ -1,0 +1,2 @@
+releases:
+  "@near-eth/nep141-erc20": patch

--- a/packages/nep141-erc20/src/bridged-nep141/deploy.js
+++ b/packages/nep141-erc20/src/bridged-nep141/deploy.js
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
 import { utils } from 'near-api-js'
 import { getNearAccount } from '@near-eth/client/dist/utils'
+import * as urlParams from '../natural-erc20/sendToNear/urlParams'
 
 /**
  * Deploy a BridgeToken contract for the given erc20Address.
@@ -35,6 +36,7 @@ import { getNearAccount } from '@near-eth/client/dist/utils'
  */
 export default async function deployBridgeToken (erc20Address) {
   const nearAccount = await getNearAccount()
+  urlParams.set({ bridging: erc20Address })
 
   // causes redirect to NEAR Wallet
   await nearAccount.functionCall(


### PR DESCRIPTION
Fix https://github.com/near/rainbow-bridge-frontend/issues/189
Wallet redirects with transactionHashes of the token deployment tx, but UI will not know that it belongs to the `bridging` of a new token without an extra param (similar to `minting`, `withdrawing`)