### PR TITLE
feat: add options for findProof()

### DIFF
--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/findProof.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/findProof.js
@@ -3,13 +3,15 @@ import bs58 from 'bs58'
 import { toBuffer } from 'ethereumjs-util'
 import { getEthProvider, getNearAccount } from '@near-eth/client/dist/utils'
 
-export default async function findProof (transfer) {
-  const web3 = new Web3(getEthProvider())
-  const nearAccount = await getNearAccount()
+export default async function findProof (transfer, options) {
+  options = options || {}
+  const ethProvider = options.ethProvider || getEthProvider()
+  const web3 = new Web3(ethProvider)
+  const nearAccount = options.nearAccount || await getNearAccount()
 
   const nearOnEthClient = new web3.eth.Contract(
-    JSON.parse(process.env.ethNearOnEthClientAbiText),
-    process.env.ethClientAddress
+    options.ethNearOnEthClientAbi || JSON.parse(process.env.ethNearOnEthClientAbiText),
+    options.ethClientAddress || process.env.ethClientAddress
   )
   const clientBlockHashB58 = bs58.encode(toBuffer(
     await nearOnEthClient.methods


### PR DESCRIPTION
The current implementation of `findProof` uses quite a few singleton
instances or env vars. The PR allows such references to be customized
using options, which is required on the server side.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>