### PR TITLE
Improve reorg handling

### DIFF
--- a/.yarn/versions/528478f0.yml
+++ b/.yarn/versions/528478f0.yml
@@ -1,0 +1,9 @@
+releases:
+  "@near-eth/aurora-erc20": prerelease
+  "@near-eth/aurora-ether": prerelease
+  "@near-eth/near-ether": prerelease
+  "@near-eth/nep141-erc20": prerelease
+  rainbow-bridge-client-monorepo: patch
+
+declined:
+  - find-replacement-tx

--- a/packages/aurora-erc20/package.json
+++ b/packages/aurora-erc20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-eth/aurora-erc20",
-  "version": "1.1.0-2",
+  "version": "1.1.0-3",
   "license": "(MIT AND Apache-2.0)",
   "main": "dist/index.js",
   "files": [

--- a/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.js
+++ b/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.js
@@ -14,7 +14,7 @@ import {
   getNearAccount,
   formatLargeNum
 } from '@near-eth/client/dist/utils'
-import { findReplacementTx, SearchError, TxValidationError } from 'find-replacement-tx'
+import { findReplacementTx, TxValidationError } from 'find-replacement-tx'
 import getErc20Name from '../../natural-erc20/getName'
 import { getDecimals } from '../../natural-erc20/getMetadata'
 
@@ -56,7 +56,7 @@ const transferDraft = {
   //   to,                       // tx.to of last broadcasted eth tx (can be multisig contract)
   //   safeReorgHeight,          // Lower boundary for replacement tx search
   //   nonce                     // tx.nonce of last broadcasted eth tx
-  //   data                     // tx.input of last broadcasted eth tx
+  //   data                     // tx.data of last broadcasted eth tx
   // }
 
   // Attributes specific to natural-erc20-to-nep141 transfers
@@ -364,7 +364,7 @@ async function checkBurn (transfer) {
       const tx = {
         nonce: transfer.ethCache.nonce,
         from: transfer.ethCache.from,
-        // TODO check data is valid when Aurora rpc is complete and contains tx.input (currently "0x")
+        // TODO check data is valid when Aurora rpc is complete and contains tx.data (currently "0x")
         data: transfer.ethCache.data,
         to: transfer.ethCache.to
       }
@@ -388,7 +388,7 @@ async function checkBurn (transfer) {
       burnReceipt = await provider.send('eth_getTransactionReceipt', [foundTx.hash])
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],
@@ -649,7 +649,7 @@ async function checkUnlock (transfer) {
       unlockReceipt = await provider.getTransactionReceipt(foundTx.hash)
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],

--- a/packages/aurora-ether/package.json
+++ b/packages/aurora-ether/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-eth/aurora-ether",
-  "version": "1.1.0-2",
+  "version": "1.1.0-3",
   "license": "(MIT AND Apache-2.0)",
   "main": "dist/index.js",
   "files": [

--- a/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.js
+++ b/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.js
@@ -15,7 +15,7 @@ import {
   getNearAccount,
   formatLargeNum
 } from '@near-eth/client/dist/utils'
-import { findReplacementTx, SearchError, TxValidationError } from 'find-replacement-tx'
+import { findReplacementTx, TxValidationError } from 'find-replacement-tx'
 
 export const SOURCE_NETWORK = 'aurora'
 export const DESTINATION_NETWORK = 'ethereum'
@@ -55,7 +55,7 @@ const transferDraft = {
   //   to,                       // tx.to of last broadcasted eth tx (can be multisig contract)
   //   safeReorgHeight,          // Lower boundary for replacement tx search
   //   nonce                     // tx.nonce of last broadcasted eth tx
-  //   data                     // tx.input of last broadcasted eth tx
+  //   data                     // tx.data of last broadcasted eth tx
   // }
 
   // Attributes specific to natural-erc20-to-nep141 transfers
@@ -325,7 +325,7 @@ async function burn (transfer) {
       to: pendingBurnTx.to,
       data: pendingBurnTx.data,
       nonce: pendingBurnTx.nonce,
-      value: pendingBurnTx.value,
+      value: pendingBurnTx.value.toString(),
       safeReorgHeight
     },
     burnHashes: [...transfer.burnHashes, txHash]
@@ -366,7 +366,7 @@ async function checkBurn (transfer) {
       burnReceipt = await provider.send('eth_getTransactionReceipt', [foundTx.hash])
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],
@@ -627,7 +627,7 @@ async function checkUnlock (transfer) {
       unlockReceipt = await provider.getTransactionReceipt(foundTx.hash)
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],

--- a/packages/aurora-ether/src/natural-ether/sendToAurora/index.js
+++ b/packages/aurora-ether/src/natural-ether/sendToAurora/index.js
@@ -3,7 +3,7 @@ import { track } from '@near-eth/client'
 import { stepsFor } from '@near-eth/client/dist/i18nHelpers'
 import * as status from '@near-eth/client/dist/statuses'
 import { getEthProvider, getSignerProvider, getNearAccount, formatLargeNum } from '@near-eth/client/dist/utils'
-import { findReplacementTx, SearchError, TxValidationError } from 'find-replacement-tx'
+import { findReplacementTx, TxValidationError } from 'find-replacement-tx'
 import { ethOnNearSyncHeight, findEthProof } from '@near-eth/utils'
 
 export const SOURCE_NETWORK = 'ethereum'
@@ -233,7 +233,8 @@ async function lock (transfer) {
       from: pendingLockTx.from,
       to: pendingLockTx.to,
       nonce: pendingLockTx.nonce,
-      data: pendingLockTx.input,
+      data: pendingLockTx.data,
+      value: pendingLockTx.value.toString(),
       safeReorgHeight
     },
     lockHashes: [...transfer.lockHashes, pendingLockTx.hash]
@@ -261,14 +262,15 @@ async function checkLock (transfer) {
         nonce: transfer.ethCache.nonce,
         from: transfer.ethCache.from,
         to: transfer.ethCache.to,
-        data: transfer.ethCache.data
+        data: transfer.ethCache.data,
+        value: transfer.ethCache.value
       }
       const foundTx = await findReplacementTx(provider, transfer.ethCache.safeReorgHeight, tx)
       if (!foundTx) return transfer
       lockReceipt = await provider.getTransactionReceipt(foundTx.hash)
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],

--- a/packages/find-replacement-tx/README.md
+++ b/packages/find-replacement-tx/README.md
@@ -68,7 +68,7 @@ const tx = {
   nonce: pendingApprovalTx.nonce,
   from: pendingApprovalTx.from,
   to: pendingApprovalTx.to,
-  data: pendingApprovalTx.input, // (optional)
+  data: pendingApprovalTx.data, // (optional)
   value: pendingApprovalTx.value // (optional)
 }
 // Validating an event is optional as tx.data should be sufficient in most cases.

--- a/packages/near-ether/package.json
+++ b/packages/near-ether/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-eth/near-ether",
-  "version": "1.2.0-2",
+  "version": "1.2.0-3",
   "license": "(MIT AND Apache-2.0)",
   "main": "dist/index.js",
   "files": [

--- a/packages/near-ether/src/bridged-ether/sendToEthereum/index.js
+++ b/packages/near-ether/src/bridged-ether/sendToEthereum/index.js
@@ -12,7 +12,7 @@ import * as status from '@near-eth/client/dist/statuses'
 import { stepsFor } from '@near-eth/client/dist/i18nHelpers'
 import { track } from '@near-eth/client'
 import { borshifyOutcomeProof, urlParams, nearOnEthSyncHeight, findNearProof } from '@near-eth/utils'
-import { findReplacementTx, SearchError, TxValidationError } from 'find-replacement-tx'
+import { findReplacementTx, TxValidationError } from 'find-replacement-tx'
 import { getEthProvider, getNearAccount, formatLargeNum, getSignerProvider } from '@near-eth/client/dist/utils'
 
 export const SOURCE_NETWORK = 'near'
@@ -683,7 +683,7 @@ async function checkUnlock (transfer) {
       unlockReceipt = await provider.getTransactionReceipt(foundTx.hash)
     } catch (error) {
       console.error(error)
-      if (error instanceof SearchError || error instanceof TxValidationError) {
+      if (error instanceof TxValidationError) {
         return {
           ...transfer,
           errors: [...transfer.errors, error.message],

--- a/packages/nep141-erc20/package.json
+++ b/packages/nep141-erc20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-eth/nep141-erc20",
-  "version": "1.6.0-2",
+  "version": "1.6.0-3",
   "license": "(MIT AND Apache-2.0)",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Find-replacement-tx can be unreliable in case of reorgs, use tx.data instead of events.
Don't catch SearchError so that it can be tried again at the next checkStatus loop.