### PR TITLE
feat: Add aurora-nep141.

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -31,6 +31,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:packages/aurora-ether"
       },
       {
+        "name": "@near-eth/aurora-nep141",
+        "reference": "workspace:packages/aurora-nep141"
+      },
+      {
         "name": "@near-eth/client",
         "reference": "workspace:packages/client"
       },
@@ -60,6 +64,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
     "fallbackExclusionList": [
       ["@near-eth/aurora-erc20", ["workspace:packages/aurora-erc20"]],
       ["@near-eth/aurora-ether", ["workspace:packages/aurora-ether"]],
+      ["@near-eth/aurora-nep141", ["workspace:packages/aurora-nep141"]],
       ["@near-eth/client", ["workspace:packages/client"]],
       ["@near-eth/near-ether", ["workspace:packages/near-ether"]],
       ["@near-eth/nep141-erc20", ["workspace:packages/nep141-erc20"]],
@@ -1167,6 +1172,33 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/aurora-ether/",
           "packageDependencies": [
             ["@near-eth/aurora-ether", "workspace:packages/aurora-ether"],
+            ["@commitlint/cli", "npm:13.0.0"],
+            ["@commitlint/config-conventional", "npm:13.0.0"],
+            ["@commitlint/travis-cli", "npm:13.0.0"],
+            ["@near-eth/client", "workspace:packages/client"],
+            ["@near-eth/utils", "workspace:packages/utils"],
+            ["@types/bn.js", "npm:5.1.0"],
+            ["@types/bs58", "npm:4.0.1"],
+            ["@types/node", "npm:14.17.5"],
+            ["@yarnpkg/pnpify", "virtual:d6e270ced375feae8aa67e695e8f6605fb9bdb5436bd33ea71c586d53ece0ac57c48d636803398a59ac1d977701119730da4426f2c7cb4803b7ff452c934acf5#npm:2.4.0"],
+            ["bn.js", "npm:5.2.0"],
+            ["bs58", "npm:4.0.1"],
+            ["ethereumjs-util", "npm:7.1.0"],
+            ["ethers", "npm:5.4.6"],
+            ["find-replacement-tx", "workspace:packages/find-replacement-tx"],
+            ["near-api-js", "https://github.com/aurora-is-near/near-api-js.git#commit=b31f9975b29c69e65c6db2feca2183fac400109e"],
+            ["promisfy", "npm:1.2.0"],
+            ["rlp", "npm:2.2.6"],
+            ["typescript", "patch:typescript@npm%3A4.1.5#builtin<compat/typescript>::version=4.1.5&hash=cc6730"]
+          ],
+          "linkType": "SOFT",
+        }]
+      ]],
+      ["@near-eth/aurora-nep141", [
+        ["workspace:packages/aurora-nep141", {
+          "packageLocation": "./packages/aurora-nep141/",
+          "packageDependencies": [
+            ["@near-eth/aurora-nep141", "workspace:packages/aurora-nep141"],
             ["@commitlint/cli", "npm:13.0.0"],
             ["@commitlint/config-conventional", "npm:13.0.0"],
             ["@commitlint/travis-cli", "npm:13.0.0"],

--- a/.yarn/versions/a44c7447.yml
+++ b/.yarn/versions/a44c7447.yml
@@ -1,0 +1,11 @@
+releases:
+  "@near-eth/aurora-erc20": patch
+  "@near-eth/aurora-nep141": major
+  "@near-eth/client": minor
+  "@near-eth/utils": minor
+  rainbow-bridge-client-monorepo: minor
+
+declined:
+  - "@near-eth/aurora-ether"
+  - "@near-eth/near-ether"
+  - "@near-eth/nep141-erc20"

--- a/packages/aurora-erc20/src/bridged-erc20/getAddress.ts
+++ b/packages/aurora-erc20/src/bridged-erc20/getAddress.ts
@@ -1,6 +1,6 @@
 import { getBridgeParams, getNearAccount } from '@near-eth/client/dist/utils'
 import { Account } from 'near-api-js'
-import { serialize as serializeBorsh } from 'near-api-js/lib/utils/serialize'
+import { aurora } from '@near-eth/utils'
 
 /**
  * Given an erc20 contract address, get the NEAR contract address of the
@@ -28,29 +28,6 @@ export default async function getAuroraErc20Address (
   const auroraEvmAccount = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount
   const nep141Factory: string = options.nep141Factory ?? bridgeParams.nep141Factory
   const nep141Address = erc20Address.replace('0x', '').toLowerCase() + '.' + nep141Factory
-  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
-  class BorshArgs {
-    constructor (args: any) {
-      Object.assign(this, args)
-    }
-  };
-  const schema = new Map([
-    [BorshArgs, {
-      kind: 'struct',
-      fields: [
-        ['nep141', 'String']
-      ]
-    }]
-  ])
-  const args = new BorshArgs({
-    nep141: nep141Address
-  })
-  const serializedArgs = serializeBorsh(schema, args)
-  const address: string = await nearAccount.viewFunction(
-    auroraEvmAccount,
-    'get_erc20_from_nep141',
-    Buffer.from(serializedArgs),
-    { parse: (result) => Buffer.from(result).toString('hex') }
-  )
-  return '0x' + address
+  const address = await aurora.getErc20FromNep141({ nep141Address, nearAccount, auroraEvmAccount })
+  return address
 }

--- a/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.ts
+++ b/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.ts
@@ -495,6 +495,7 @@ export async function checkBurn (
       'Wrong eth network for checkLock, expected: %s, got: %s',
       expectedChainId, ethChainId
     )
+    return transfer
   }
   // Ethers formats the receipts and removes nearTransactionHash
   let burnReceipt = await provider.send('eth_getTransactionReceipt', [burnHash])

--- a/packages/aurora-nep141/LICENSE
+++ b/packages/aurora-nep141/LICENSE
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/packages/aurora-nep141/LICENSE-APACHE
+++ b/packages/aurora-nep141/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/aurora-nep141/README.md
+++ b/packages/aurora-nep141/README.md
@@ -1,0 +1,15 @@
+`@near-eth/aurora-nep141`
+========================
+<a href="https://www.npmjs.com/package/@near-eth/aurora-nep141"><img alt="@near-eth/aurora-nep141 Version" src="https://img.shields.io/npm/v/@near-eth/aurora-nep141"></a>
+
+A Connector Library for sending [NEP141] tokens to Aurora.
+
+This is a Connector Library that integrates with [@near-eth/client]. For detailed instructions on how to use it, see the README there.
+
+This package makes it easy for your app (or, someday, CLI) to send *Fungible Tokens* from NEAR to Aurora. It lets you send [NEP141] (NEAR's Fungible Token Standard) Tokens to Aurora where they become [ERC20] (Ethereum's Fungible Token standard), and can then be sent back again.
+
+These transfers between NEAR and Aurora don't happen over the Rainbow Bridge so they are instantaneous and a single Aurora or NEAR transaction is needed.
+
+  [@near-eth/client]: https://www.npmjs.com/package/@near-eth/client
+  [ERC20]: https://eips.ethereum.org/EIPS/eip-20
+  [NEP141]: https://github.com/near/NEPs/issues/141

--- a/packages/aurora-nep141/package.json
+++ b/packages/aurora-nep141/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@near-eth/aurora-nep141",
+  "version": "0.0.0",
+  "license": "(MIT AND Apache-2.0)",
+  "main": "dist/index.js",
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "build": "rm -rf dist && tsc --build tsconfig.json"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "*",
+    "@commitlint/config-conventional": "*",
+    "@commitlint/travis-cli": "*",
+    "@types/bn.js": "^5.1.0",
+    "@types/bs58": "^4.0.1",
+    "@types/node": "^14.14.28",
+    "@yarnpkg/pnpify": "^2.4.0",
+    "typescript": "4.1.5"
+  },
+  "dependencies": {
+    "@near-eth/client": "workspace:*",
+    "@near-eth/utils": "workspace:*",
+    "bn.js": "^5.1.3",
+    "bs58": "^4.0.1",
+    "ethereumjs-util": "^7.0.10",
+    "ethers": "^5.4.6",
+    "find-replacement-tx": "workspace:*",
+    "near-api-js": "https://github.com/aurora-is-near/near-api-js#b31f9975b29c69e65c6db2feca2183fac400109e",
+    "promisfy": "^1.2.0",
+    "rlp": "^2.2.6"
+  },
+  "browserslist": [
+    "since 2017-04"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aurora-is-near/rainbow-bridge-client/tree/main/packages/nep141-erc20"
+  }
+}

--- a/packages/aurora-nep141/src/bridged-erc20/deploy.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/deploy.ts
@@ -1,0 +1,51 @@
+import BN from 'bn.js'
+import { FinalExecutionOutcome } from 'near-api-js/lib/providers'
+import { serialize as serializeBorsh } from 'near-api-js/lib/utils/serialize'
+import { Account } from 'near-api-js'
+import { getNearAccount } from '@near-eth/client/dist/utils'
+import { getBridgeParams } from '@near-eth/client'
+import { urlParams } from '@near-eth/utils'
+
+export default async function deployToAurora (
+  { nep141Address, options }: {
+    nep141Address: string
+    options?: {
+      nearAccount?: Account
+      auroraEvmAccount?: string
+    }
+  }
+): Promise<FinalExecutionOutcome> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+  class BorshArg {
+    constructor (proof: any) {
+      Object.assign(this, proof)
+    }
+  }
+
+  const borshArgSchema = new Map([
+    [BorshArg, {
+      kind: 'struct',
+      fields: [
+        ['nep141', ['u8']]
+      ]
+    }]
+  ])
+  const borshArg = new BorshArg({
+    nep141: Buffer.from(nep141Address)
+  })
+
+  const arg = serializeBorsh(borshArgSchema, borshArg)
+
+  urlParams.set({ bridging: nep141Address })
+  const tx = await nearAccount.functionCall({
+    contractId: options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount,
+    methodName: 'deploy_erc20_token',
+    args: arg,
+    gas: new BN('100' + '0'.repeat(12)),
+    attachedDeposit: new BN('3' + '0'.repeat(24))
+  })
+  return tx
+}

--- a/packages/aurora-nep141/src/bridged-erc20/getAddress.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/getAddress.ts
@@ -1,0 +1,71 @@
+import { getBridgeParams, getNearAccount } from '@near-eth/client/dist/utils'
+import { Account } from 'near-api-js'
+import { aurora } from '@near-eth/utils'
+
+const auroraErc20Addresses: {[key: string]: string} = {}
+const nep141Addresses: {[key: string]: string} = {}
+
+/**
+ * Given an nep141 contract address, get the Aurora erc20 contract address of the
+ * corresponding BridgeToken contract.
+ *
+ * @param params Uses Named Arguments pattern, please pass arguments as object
+ * @param params.nep141Address Contract address of an NEP-141 token on NEAR
+ * @param params.options Optional arguments.
+ * @returns string Contract address of ERC-20 BridgeToken on Aurora
+ */
+export async function getAuroraErc20Address (
+  { nep141Address, options }: {
+    nep141Address: string
+    options?: {
+      nearAccount?: Account
+      auroraEvmAccount?: string
+    }
+  }
+): Promise<string | null> {
+  if (auroraErc20Addresses[nep141Address]) return auroraErc20Addresses[nep141Address]!
+  options = options ?? {}
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const bridgeParams = getBridgeParams()
+  const auroraEvmAccount: string = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount
+  try {
+    const address = await aurora.getErc20FromNep141({ nep141Address, nearAccount, auroraEvmAccount })
+    auroraErc20Addresses[nep141Address] = address
+  } catch (error) {
+    console.error(error, nep141Address)
+    return null
+  }
+  return auroraErc20Addresses[nep141Address]!
+}
+
+/**
+ * Given a bridged ERC-20 contract address, get the original NEP-141 contract address.
+ *
+ * @param params Uses Named Arguments pattern, please pass arguments as object
+ * @param params.auroraErc20Address Contract address of a bridged ERC-20 token on Aurora
+ * @param params.options Optional arguments.
+ * @returns string Contract address of NEP-141 token on NEAR
+ */
+export async function getNep141Address (
+  { auroraErc20Address, options }: {
+    auroraErc20Address: string
+    options?: {
+      nearAccount?: Account
+      auroraEvmAccount?: string
+    }
+  }
+): Promise<string | null> {
+  if (nep141Addresses[auroraErc20Address]) return nep141Addresses[auroraErc20Address]!
+  options = options ?? {}
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const bridgeParams = getBridgeParams()
+  const auroraEvmAccount: string = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount
+  try {
+    const address = await aurora.getNep141FromErc20({ auroraErc20Address, nearAccount, auroraEvmAccount })
+    nep141Addresses[auroraErc20Address] = address
+  } catch (error) {
+    console.error(error, auroraErc20Address)
+    return null
+  }
+  return nep141Addresses[auroraErc20Address]!
+}

--- a/packages/aurora-nep141/src/bridged-erc20/getBalance.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/getBalance.ts
@@ -1,0 +1,22 @@
+import { ethers } from 'ethers'
+import { getAuroraProvider, getBridgeParams } from '@near-eth/client/dist/utils'
+import { erc20 } from '@near-eth/utils'
+
+export default async function getBalance (
+  { erc20Address, owner, options }: {
+    erc20Address: string
+    owner: string
+    options?: {
+      provider?: ethers.providers.Provider
+      auroraErc20Abi?: string
+    }
+  }
+): Promise<string> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const provider = options.provider ?? getAuroraProvider()
+  const erc20Abi = options.auroraErc20Abi ?? bridgeParams.auroraErc20Abi
+
+  const balance = await erc20.getBalance({ erc20Address, owner, provider, erc20Abi })
+  return balance
+}

--- a/packages/aurora-nep141/src/bridged-erc20/index.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/index.ts
@@ -1,0 +1,4 @@
+export { sendToNear, sendEthToNear } from './sendToNear'
+export { default as deploy } from './deploy'
+export { getAuroraErc20Address, getNep141Address } from './getAddress'
+export { default as getBalance } from './getBalance'

--- a/packages/aurora-nep141/src/bridged-erc20/sendToNear/index.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/sendToNear/index.ts
@@ -10,6 +10,8 @@ export const SOURCE_NETWORK = 'aurora'
 export const DESTINATION_NETWORK = 'near'
 export const TRANSFER_TYPE = '@near-eth/aurora-nep141/bridged-erc20/sendToNear'
 
+const BURN = 'burn-bridged-erc20-to-near'
+
 export interface TransferDraft extends TransferStatus {
   type: string
   burnHashes: string[]
@@ -128,6 +130,7 @@ export async function checkBurn (
   return {
     ...transfer,
     status: status.COMPLETE,
+    completedStep: BURN,
     startTime: new Date(txBlock.timestamp * 1000).toISOString(),
     burnReceipts: [...transfer.burnReceipts, receipt]
   }
@@ -230,7 +233,7 @@ export async function burn (
       data: tx.data,
       safeReorgHeight
     },
-    burnHashes: [tx.hash]
+    burnHashes: [...transfer.burnHashes, tx.hash]
   }
 }
 
@@ -323,7 +326,7 @@ export async function burnEth (
       data: tx.data,
       safeReorgHeight
     },
-    burnHashes: [tx.hash]
+    burnHashes: [...transfer.burnHashes, tx.hash]
   }
 }
 

--- a/packages/aurora-nep141/src/bridged-erc20/sendToNear/index.ts
+++ b/packages/aurora-nep141/src/bridged-erc20/sendToNear/index.ts
@@ -1,0 +1,330 @@
+import { ethers } from 'ethers'
+import { Account } from 'near-api-js'
+import { getAuroraProvider, getSignerProvider, getBridgeParams, track } from '@near-eth/client'
+import { TransactionInfo, TransferStatus } from '@near-eth/client/dist/types'
+import * as status from '@near-eth/client/dist/statuses'
+import { getAuroraErc20Address } from '../getAddress'
+import { getMetadata } from '../../natural-nep141'
+
+export const SOURCE_NETWORK = 'aurora'
+export const DESTINATION_NETWORK = 'near'
+export const TRANSFER_TYPE = '@near-eth/aurora-nep141/bridged-erc20/sendToNear'
+
+export interface TransferDraft extends TransferStatus {
+  type: string
+  burnHashes: string[]
+  burnReceipts: ethers.providers.TransactionReceipt[]
+}
+
+export interface Transfer extends TransactionInfo, TransferDraft {
+  id: string
+  decimals: number
+  destinationTokenName: string
+  recipient: string
+  sender: string
+  sourceTokenName: string
+  symbol: string
+  startTime?: string
+}
+
+const transferDraft: TransferDraft = {
+  // Attributes common to all transfer types
+  // amount,
+  completedStep: null,
+  // destinationTokenName,
+  errors: [],
+  // recipient,
+  // sender,
+  // sourceToken: erc20Address,
+  // sourceTokenName,
+  // decimals,
+  status: status.IN_PROGRESS,
+  type: TRANSFER_TYPE,
+  // Cache eth tx information used for finding a replaced (speedup/cancel) tx.
+  // ethCache: {
+  //   from,                     // tx.from of last broadcasted eth tx
+  //   to,                       // tx.to of last broadcasted eth tx (can be multisig contract)
+  //   safeReorgHeight,          // Lower boundary for replacement tx search
+  //   nonce                     // tx.nonce of last broadcasted eth tx
+  // }
+
+  // Attributes specific to natural-erc20-to-nep141 transfers
+  burnHashes: [],
+  burnReceipts: []
+}
+
+export const i18n = {
+  en_US: {
+    steps: (_transfer: Transfer) => [],
+    statusMessage: (transfer: Transfer) => {
+      switch (transfer.status) {
+        case 'in-progress': return 'Confirming transaction'
+        case 'failed': return 'Failed: check transaction status from Wallet'
+        default: return 'Completed'
+      }
+    },
+    callToAction: (transfer: Transfer) => {
+      if (transfer.status === status.FAILED) return 'Retry'
+      return null
+    }
+  }
+}
+
+/**
+ * Called when status is FAILED
+ * @param transfer Transfer object to act on.
+ */
+export async function act (transfer: Transfer): Promise<Transfer> {
+  switch (transfer.completedStep) {
+    case null:
+      if (transfer.sourceToken === 'ETH') {
+        return await burnEth(transfer)
+      } else {
+        return await burn(transfer)
+      }
+    default: throw new Error(`Don't know how to act on transfer: ${JSON.stringify(transfer)}`)
+  }
+}
+
+export async function checkStatus (transfer: Transfer): Promise<Transfer> {
+  switch (transfer.completedStep) {
+    case null: return await checkBurn(transfer)
+    default: throw new Error(`Don't know how to checkStatus for transfer ${transfer.id}`)
+  }
+}
+
+export async function checkBurn (
+  transfer: Transfer,
+  options?: {
+    provider?: ethers.providers.Provider
+    auroraChainId?: number
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const provider = options.provider ?? getAuroraProvider()
+  // TODO find replacement tx
+  const ethChainId = (await provider.getNetwork()).chainId
+  const expectedChainId = options.auroraChainId ?? bridgeParams.auroraChainId
+  if (ethChainId !== expectedChainId) {
+    // Webapp should prevent the user from confirming if the wrong network is selected
+    console.log(
+      'Wrong aurora network for checkBurn, expected: %s, got: %s',
+      expectedChainId, ethChainId
+    )
+    return transfer
+  }
+  const receipt = await provider.getTransactionReceipt(last(transfer.burnHashes))
+  if (!receipt) return transfer
+  if (!receipt.status || receipt.status !== 1) {
+    return {
+      ...transfer,
+      status: status.FAILED,
+      burnReceipts: [...transfer.burnReceipts, receipt],
+      errors: [...transfer.errors, 'Execution failed']
+    }
+  }
+  const txBlock = await provider.getBlock(receipt.blockHash)
+  return {
+    ...transfer,
+    status: status.COMPLETE,
+    startTime: new Date(txBlock.timestamp * 1000).toISOString(),
+    burnReceipts: [...transfer.burnReceipts, receipt]
+  }
+}
+
+// export async function sendToNear (erc20Address, amount, decimals, name) {
+export async function sendToNear (
+  { nep141Address, amount, recipient, options }: {
+    nep141Address: string
+    amount: string | ethers.BigNumber
+    recipient: string
+    options?: {
+      symbol?: string
+      decimals?: number
+      sender?: string
+      ethChainId?: number
+      provider?: ethers.providers.JsonRpcProvider
+      auroraErc20Abi?: string
+      auroraErc20Address?: string
+      signer?: ethers.Signer
+      nearAccount?: Account
+      auroraEvmAccount?: string
+    }
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const provider = options.provider ?? getSignerProvider()
+  let metadata = { symbol: nep141Address.slice(0, 5) + '...', decimals: 0 }
+  if (!options.symbol || !options.decimals) {
+    metadata = await getMetadata({ nep141Address, options })
+  }
+  const symbol: string = options.symbol ?? metadata.symbol
+  const sourceTokenName = 'a' + symbol
+  const destinationTokenName = symbol
+  const decimals = options.decimals ?? metadata.decimals
+  const signer = options.signer ?? provider.getSigner()
+  const sender = options.sender ?? (await signer.getAddress()).toLowerCase()
+  const auroraErc20Address = options.auroraErc20Address ?? await getAuroraErc20Address({ nep141Address, options })
+  if (!auroraErc20Address) throw new Error(`Token not bridged: ${nep141Address}`)
+
+  let transfer: Transfer = {
+    ...transferDraft,
+    id: new Date().toISOString(),
+    amount: amount.toString(),
+    decimals,
+    symbol,
+    sourceToken: auroraErc20Address,
+    sourceTokenName,
+    destinationTokenName,
+    sender,
+    recipient
+  }
+
+  transfer = await burn(transfer, options)
+
+  if (typeof window !== 'undefined') transfer = await track(transfer) as Transfer
+  return transfer
+}
+
+export async function burn (
+  transfer: Transfer,
+  options?: {
+    provider?: ethers.providers.JsonRpcProvider
+    auroraChainId?: number
+    auroraErc20Abi?: string
+    signer?: ethers.Signer
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const provider = options.provider ?? getSignerProvider()
+
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.auroraChainId ?? bridgeParams.auroraChainId
+  if (ethChainId !== expectedChainId) {
+    // Webapp should prevent the user from confirming if the wrong network is selected
+    throw new Error(
+      `Wrong eth network for burn, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
+  const erc20Contract = new ethers.Contract(
+    transfer.sourceToken,
+    options.auroraErc20Abi ?? bridgeParams.auroraErc20Abi,
+    options.signer ?? provider.getSigner()
+  )
+  const safeReorgHeight = await provider.getBlockNumber() - 20
+  const tx = await erc20Contract.withdrawToNear(
+    Buffer.from(transfer.recipient),
+    transfer.amount,
+    { gasLimit: 100000 }
+  )
+  return {
+    ...transfer,
+    status: status.IN_PROGRESS,
+    ethCache: {
+      from: tx.from,
+      to: tx.to,
+      nonce: tx.nonce,
+      data: tx.data,
+      safeReorgHeight
+    },
+    burnHashes: [tx.hash]
+  }
+}
+
+// export async function withdrawEthToNear (amount) {
+export async function sendEthToNear (
+  { amount, recipient, options }: {
+    amount: string | ethers.BigNumber
+    recipient: string
+    options?: {
+      symbol?: string
+      decimals?: number
+      sender?: string
+      ethChainId?: number
+      provider?: ethers.providers.JsonRpcProvider
+      signer?: ethers.Signer
+      exitToNearPrecompile?: string
+    }
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const provider = options.provider ?? getSignerProvider()
+  const symbol = options.symbol ?? 'ETH'
+  const sourceTokenName = 'a' + symbol
+  const destinationTokenName = sourceTokenName
+  const sourceToken = 'ETH'
+  const decimals = options.decimals ?? 18
+  const signer = options.signer ?? provider.getSigner()
+  const sender = options.sender ?? (await signer.getAddress()).toLowerCase()
+
+  let transfer: Transfer = {
+    ...transferDraft,
+    id: new Date().toISOString(),
+    amount: amount.toString(),
+    symbol,
+    sourceToken,
+    sourceTokenName,
+    destinationTokenName,
+    decimals,
+    sender,
+    recipient
+  }
+
+  transfer = await burnEth(transfer, options)
+
+  if (typeof window !== 'undefined') transfer = await track(transfer) as Transfer
+  return transfer
+}
+
+export async function burnEth (
+  transfer: Transfer,
+  options?: {
+    provider?: ethers.providers.JsonRpcProvider
+    auroraChainId?: number
+    exitToNearPrecompile?: string
+    signer?: ethers.Signer
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const provider = options.provider ?? getSignerProvider()
+
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.auroraChainId ?? bridgeParams.auroraChainId
+  if (ethChainId !== expectedChainId) {
+    // Webapp should prevent the user from confirming if the wrong network is selected
+    throw new Error(
+      `Wrong eth network for burn, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
+  const exitToNearPrecompile = options.exitToNearPrecompile ?? bridgeParams.exitToNearPrecompile // '0xe9217bc70b7ed1f598ddd3199e80b093fa71124f'
+  const exitToNearData = '0x00' + Buffer.from(transfer.recipient).toString('hex')
+  const safeReorgHeight = await provider.getBlockNumber() - 20
+  const txHash = await provider.send('eth_sendTransaction', [{
+    from: transfer.sender,
+    to: exitToNearPrecompile,
+    value: ethers.BigNumber.from(transfer.amount).toHexString(),
+    data: exitToNearData,
+    gas: ethers.BigNumber.from(121000).toHexString()
+  }])
+  const tx = await provider.getTransaction(txHash)
+
+  return {
+    ...transfer,
+    status: status.IN_PROGRESS,
+    ethCache: {
+      from: tx.from,
+      to: tx.to!,
+      nonce: tx.nonce,
+      data: tx.data,
+      safeReorgHeight
+    },
+    burnHashes: [tx.hash]
+  }
+}
+
+const last = (arr: any[]): any => arr[arr.length - 1]

--- a/packages/aurora-nep141/src/index.ts
+++ b/packages/aurora-nep141/src/index.ts
@@ -1,0 +1,2 @@
+export * as bridgedErc20 from './bridged-erc20'
+export * as naturalNep141 from './natural-nep141'

--- a/packages/aurora-nep141/src/natural-nep141/getBalance.ts
+++ b/packages/aurora-nep141/src/natural-nep141/getBalance.ts
@@ -1,0 +1,29 @@
+import { getNearAccount } from '@near-eth/client/dist/utils'
+import { Account } from 'near-api-js'
+import { nep141 } from '@near-eth/utils'
+
+/**
+ * Given an NEP-141 contract address, get the owner's balance.
+ *
+ * @param params Uses Named Arguments pattern, please pass arguments as object
+ * @param params.nep141Address Contract address of an NEP-141 token on NEAR
+ * @param params.owner NEAR account address
+ * @param params.options Optional arguments.
+ * @param params.options.nearAccount Connected NEAR wallet account to use.
+ *
+ * @returns Balance as string
+ */
+export default async function getBalance (
+  { nep141Address, owner, options }: {
+    nep141Address: string
+    owner: string
+    options?: {
+      nearAccount?: Account
+    }
+  }
+): Promise<string> {
+  options = options ?? {}
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const balanceAsString = await nep141.getBalance({ nep141Address, owner, nearAccount })
+  return balanceAsString
+}

--- a/packages/aurora-nep141/src/natural-nep141/getMetadata.ts
+++ b/packages/aurora-nep141/src/natural-nep141/getMetadata.ts
@@ -1,0 +1,22 @@
+import { Account } from 'near-api-js'
+import { nep141 } from '@near-eth/utils'
+import { getNearAccount } from '@near-eth/client/dist/utils'
+
+const tokenMetadata: {[key: string]: {symbol: string, decimals: number}} = {}
+
+export default async function getMetadata (
+  { nep141Address, options }: {
+    nep141Address: string
+    options?: {
+      nearAccount?: Account
+    }
+  }
+): Promise<{symbol: string, decimals: number}> {
+  options = options ?? {}
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  if (tokenMetadata[nep141Address]) return tokenMetadata[nep141Address]!
+
+  const metadata = await nep141.getMetadata({ nep141Address, nearAccount })
+  tokenMetadata[nep141Address] = metadata
+  return metadata
+}

--- a/packages/aurora-nep141/src/natural-nep141/index.ts
+++ b/packages/aurora-nep141/src/natural-nep141/index.ts
@@ -1,0 +1,3 @@
+export { sendToAurora, wrapAndSendNearToAurora } from './sendToAurora'
+export { default as getMetadata } from './getMetadata'
+export { default as getBalance } from './getBalance'

--- a/packages/aurora-nep141/src/natural-nep141/sendToAurora/index.ts
+++ b/packages/aurora-nep141/src/natural-nep141/sendToAurora/index.ts
@@ -1,0 +1,352 @@
+import BN from 'bn.js'
+import { ethers } from 'ethers'
+import { transactions, Account } from 'near-api-js'
+import { getBridgeParams, track } from '@near-eth/client'
+import { TransactionInfo, TransferStatus } from '@near-eth/client/dist/types'
+import * as status from '@near-eth/client/dist/statuses'
+import { getNearAccount } from '@near-eth/client/dist/utils'
+import { urlParams } from '@near-eth/utils'
+
+export const SOURCE_NETWORK = 'near'
+export const DESTINATION_NETWORK = 'aurora'
+export const TRANSFER_TYPE = '@near-eth/aurora-nep141/natural-nep141/sendToAurora'
+
+export interface TransferDraft extends TransferStatus {
+  type: string
+  lockHashes: string[]
+  lockReceiptIds: string[]
+}
+
+export interface Transfer extends TransactionInfo, TransferDraft {
+  id: string
+  decimals: number
+  destinationTokenName: string
+  recipient: string
+  sender: string
+  sourceTokenName: string
+  symbol: string
+  startTime?: string
+}
+
+const transferDraft: TransferDraft = {
+  // Attributes common to all transfer types
+  // amount,
+  completedStep: null,
+  // destinationTokenName,
+  errors: [],
+  // recipient,
+  // sender,
+  // sourceToken,
+  // sourceTokenName,
+  // decimals,
+  status: status.IN_PROGRESS,
+  type: TRANSFER_TYPE,
+
+  // Attributes specific to natural-erc20-to-nep141 transfers
+  lockHashes: [],
+  lockReceiptIds: []
+}
+
+export const i18n = {
+  en_US: {
+    steps: (_transfer: Transfer) => [],
+    statusMessage: (transfer: Transfer) => {
+      switch (transfer.status) {
+        case 'in-progress': return 'Confirming transaction'
+        case 'failed': return last(transfer.errors)
+        default: return 'Completed'
+      }
+    },
+    callToAction: (transfer: Transfer) => {
+      if (transfer.status === status.FAILED) return 'Retry'
+      return null
+    }
+  }
+}
+
+/**
+ * Called when status is FAILED
+ * @param transfer Transfer object to act on.
+ */
+export async function act (transfer: Transfer): Promise<Transfer> {
+  switch (transfer.completedStep) {
+    case null:
+      if (transfer.sourceToken === 'NEAR') {
+        return await lockNear(transfer)
+      } else {
+        return await lock(transfer)
+      }
+    default: throw new Error(`Don't know how to act on transfer: ${JSON.stringify(transfer)}`)
+  }
+}
+
+export async function checkStatus (transfer: Transfer): Promise<Transfer> {
+  const id = urlParams.get('locking') as string
+  const txHash = urlParams.get('transactionHashes') as string | null
+  const errorCode = urlParams.get('errorCode') as string | null
+  if (!id) {
+    // The user closed the tab and never rejected or approved the tx from Near wallet.
+    // This doesn't protect against the user broadcasting a tx and closing the tab before
+    // redirect. So the dapp has no way of knowing the status of that transaction.
+    const newError = 'Failed to process NEAR Wallet transaction.'
+    console.error(newError)
+    return {
+      ...transfer,
+      status: status.FAILED,
+      errors: [newError]
+    }
+  }
+  if (id !== transfer.id) {
+    const newError = `Couldn't determine transaction outcome.
+      Got transfer id '${id} in URL, expected '${transfer.id}`
+    console.error(newError)
+    return { ...transfer, status: status.FAILED, errors: [`Failed: ${newError}`] }
+  }
+  if (errorCode) {
+    urlParams.clear('errorCode', 'errorMessage', 'locking')
+    return { ...transfer, status: status.FAILED, errors: [`Failed: ${errorCode}`] }
+  }
+  if (txHash) {
+    urlParams.clear('transactionHashes', 'locking')
+    return { ...transfer, status: status.COMPLETE, lockHashes: [txHash] }
+  }
+  console.log('Waiting for Near wallet redirect to sign lock')
+  return transfer
+}
+
+export async function sendToAurora (
+  { nep141Address, amount, recipient, options }: {
+    nep141Address: string
+    amount: string | ethers.BigNumber
+    recipient: string
+    options?: {
+      symbol?: string
+      decimals?: number
+      sender?: string
+      nearAccount?: Account
+      auroraEvmAccount?: string
+    }
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const symbol = options.symbol ?? 'TODO' // query nep141 metadata await getSymbol({ erc20Address, options })
+  const destinationTokenName = 'a' + symbol
+  const sourceTokenName = symbol
+  const decimals = options.decimals ?? 18 // query nep141 metadata await getDecimals({ erc20Address, options })
+  const sourceToken = nep141Address
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const sender = options.sender ?? nearAccount.accountId
+
+  let transfer = {
+    ...transferDraft,
+    id: new Date().toISOString(),
+    amount: amount.toString(),
+    decimals,
+    symbol,
+    sourceToken,
+    sourceTokenName,
+    destinationTokenName,
+    sender,
+    recipient
+  }
+  transfer = await lock(transfer, options)
+
+  return transfer
+}
+
+export async function lock (
+  transfer: Transfer,
+  options?: {
+    nearAccount?: Account
+    auroraEvmAccount?: string
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const auroraEvmAccount = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount
+
+  // nETH (aurora) transfers to Aurora have a different protocol:
+  // <relayer_id>:<fee(32 bytes)><eth_address_receiver(20 bytes)>
+  const msgPrefix = transfer.sourceToken === auroraEvmAccount ? transfer.sender + ':' + '0'.repeat(64) : ''
+
+  // When re-trying withdraw in frontend, withdraw is called directly by act() so we need to store
+  // in-progress status in localStorage before redirect.
+  transfer = { ...transfer, status: status.IN_PROGRESS }
+
+  // Prevent checkStatus from creating failed transfer when called between track and withdraw
+  // `track` does not override the transfer.id
+  if (typeof window !== 'undefined') urlParams.set({ locking: transfer.id })
+  if (typeof window !== 'undefined') transfer = await track(transfer) as Transfer
+
+  // If function call error, the transfer will be pending until the transaction id id cleared
+  // and the transfer is set to FAILED by checkStatus.
+  const tx = await nearAccount.functionCall({
+    contractId: transfer.sourceToken,
+    methodName: 'ft_transfer_call',
+    args: {
+      receiver_id: auroraEvmAccount,
+      amount: transfer.amount,
+      memo: null,
+      msg: msgPrefix + transfer.recipient.toLowerCase().slice(2)
+    },
+    gas: new BN('70' + '0'.repeat(12)),
+    attachedDeposit: new BN('1')
+  })
+  return {
+    ...transfer,
+    lockHashes: [tx.transaction.hash]
+  }
+}
+
+export async function wrapAndSendNearToAurora (
+  { amount, recipient, options }: {
+    amount: string | ethers.BigNumber
+    recipient: string
+    options?: {
+      symbol?: string
+      sender?: string
+      nearAccount?: Account
+      auroraEvmAccount?: string
+      wNearNep141?: string
+    }
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const symbol = options.symbol ?? 'NEAR'
+  const destinationTokenName = 'a' + symbol
+  const sourceTokenName = symbol
+  const sourceToken = 'NEAR'
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const sender = options.sender ?? nearAccount.accountId
+
+  let transfer: Transfer = {
+    ...transferDraft,
+    id: new Date().toISOString(),
+    amount: amount.toString(),
+    decimals: 24,
+    symbol,
+    sourceToken,
+    sourceTokenName,
+    destinationTokenName,
+    sender,
+    recipient
+  }
+  transfer = await lockNear(transfer, options)
+
+  return transfer
+}
+
+export async function lockNear (
+  transfer: Transfer,
+  options?: {
+    nearAccount?: Account
+    auroraEvmAccount?: string
+    wNearNep141?: string
+  }
+): Promise<Transfer> {
+  options = options ?? {}
+  const bridgeParams = getBridgeParams()
+  const nearAccount = options.nearAccount ?? await getNearAccount()
+  const wNearNep141 = options.wNearNep141 ?? bridgeParams.wNearNep141
+  const auroraEvmAccount = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount
+
+  const actions = []
+  const minStorageBalance = await getMinStorageBalance({
+    nep141Address: wNearNep141, nearAccount
+  })
+  const userStorageBalance = await getStorageBalance({
+    nep141Address: wNearNep141,
+    accountId: transfer.sender,
+    nearAccount
+  })
+  if (!userStorageBalance || new BN(userStorageBalance.total).lt(new BN(minStorageBalance))) {
+    actions.push(transactions.functionCall(
+      'storage_deposit',
+      Buffer.from(JSON.stringify({
+        account_id: transfer.sender,
+        registration_only: true
+      })),
+      new BN('50' + '0'.repeat(12)),
+      new BN(minStorageBalance)
+    ))
+  }
+
+  actions.push(transactions.functionCall(
+    'near_deposit',
+    Buffer.from(JSON.stringify({})),
+    new BN('30' + '0'.repeat(12)),
+    new BN(transfer.amount)
+  ))
+  actions.push(transactions.functionCall(
+    'ft_transfer_call',
+    Buffer.from(JSON.stringify({
+      receiver_id: auroraEvmAccount,
+      amount: transfer.amount,
+      memo: null,
+      msg: transfer.recipient.toLowerCase().slice(2)
+    })),
+    new BN('70' + '0'.repeat(12)),
+    new BN('1')
+  ))
+  // When re-trying withdraw in frontend, withdraw is called directly by act() so we need to store
+  // in-progress status in localStorage before redirect.
+  transfer = { ...transfer, status: status.IN_PROGRESS }
+
+  // Prevent checkStatus from creating failed transfer when called between track and withdraw
+  if (typeof window !== 'undefined') urlParams.set({ locking: transfer.id })
+  // `track` does not override the transfer.id
+  if (typeof window !== 'undefined') transfer = await track(transfer) as Transfer
+
+  // If function call error, the transfer will be pending until the transaction id id cleared
+  // and the transfer is set to FAILED by checkStatus.
+  // @ts-expect-error
+  const tx = await nearAccount.signAndSendTransaction(wNearNep141, actions)
+  return {
+    ...transfer,
+    lockHashes: [tx.transaction.hash]
+  }
+}
+
+export async function getMinStorageBalance (
+  { nep141Address, nearAccount }: {
+    nep141Address: string
+    nearAccount: Account
+  }
+): Promise<string> {
+  try {
+    const balance = await nearAccount.viewFunction(
+      nep141Address,
+      'storage_balance_bounds'
+    )
+    return balance.min
+  } catch (e) {
+    const balance = await nearAccount.viewFunction(
+      nep141Address,
+      'storage_minimum_balance'
+    )
+    return balance
+  }
+}
+
+export async function getStorageBalance (
+  { nep141Address, accountId, nearAccount }: {
+    nep141Address: string
+    accountId: string
+    nearAccount: Account
+  }
+): Promise<null | {total: string}> {
+  try {
+    const balance = await nearAccount.viewFunction(
+      nep141Address,
+      'storage_balance_of',
+      { account_id: accountId }
+    )
+    return balance
+  } catch (e) {
+    console.warn(e, nep141Address)
+    return null
+  }
+}
+
+const last = (arr: any[]): any => arr[arr.length - 1]

--- a/packages/aurora-nep141/tsconfig.json
+++ b/packages/aurora-nep141/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/*"],
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -57,6 +57,10 @@ function getTransferType (transfer: Transfer): ConnectorLib {
         return require('@near-eth/aurora-ether/dist/natural-ether/sendToAurora')
       case '@near-eth/aurora-ether/bridged-ether/sendToEthereum':
         return require('@near-eth/aurora-ether/dist/bridged-ether/sendToEthereum')
+      case '@near-eth/aurora-nep141/natural-nep141/sendToAurora':
+        return require('@near-eth/aurora-nep141/dist/natural-nep141/sendToAurora')
+      case '@near-eth/aurora-nep141/bridged-erc20/sendToNear':
+        return require('@near-eth/aurora-nep141/dist/bridged-erc20/sendToNear')
       default:
         throw new Error(`Unregistered library for transfer with type=${transfer.type}`)
     }

--- a/packages/utils/src/aurora.ts
+++ b/packages/utils/src/aurora.ts
@@ -1,0 +1,52 @@
+import { Account } from 'near-api-js'
+import { serialize as serializeBorsh } from 'near-api-js/lib/utils/serialize'
+
+export async function getErc20FromNep141 (
+  { nep141Address, nearAccount, auroraEvmAccount }: {
+    nep141Address: string
+    nearAccount: Account
+    auroraEvmAccount: string
+  }
+): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+  class BorshArgs {
+    constructor (args: any) {
+      Object.assign(this, args)
+    }
+  };
+  const schema = new Map([
+    [BorshArgs, {
+      kind: 'struct',
+      fields: [
+        ['nep141', 'String']
+      ]
+    }]
+  ])
+  const args = new BorshArgs({
+    nep141: nep141Address
+  })
+  const serializedArgs = serializeBorsh(schema, args)
+  const address: string = await nearAccount.viewFunction(
+    auroraEvmAccount,
+    'get_erc20_from_nep141',
+    Buffer.from(serializedArgs),
+    { parse: (result) => Buffer.from(result).toString('hex') }
+  )
+  return '0x' + address
+}
+
+export async function getNep141FromErc20 (
+  { auroraErc20Address, nearAccount, auroraEvmAccount }: {
+    auroraErc20Address: string
+    nearAccount: Account
+    auroraEvmAccount: string
+  }
+): Promise<string> {
+  const address: string = await nearAccount.viewFunction(
+    auroraEvmAccount,
+    'get_nep141_from_erc20',
+    Buffer.from(auroraErc20Address.toLowerCase().slice(2), 'hex'),
+    { parse: (result) => Buffer.from(result).toString('utf-8') }
+  )
+  return address
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,7 @@
 export * as urlParams from './url-params'
 export * as erc20 from './erc20'
+export * as nep141 from './nep141'
+export * as aurora from './aurora'
 export { borshifyOutcomeProof } from './borshify-proof'
 export { ethOnNearSyncHeight } from './ethOnNearClient'
 export { nearOnEthSyncHeight } from './nearOnEthClient'

--- a/packages/utils/src/nep141.ts
+++ b/packages/utils/src/nep141.ts
@@ -1,0 +1,29 @@
+import { Account } from 'near-api-js'
+
+export async function getMetadata (
+  { nep141Address, nearAccount }: {
+    nep141Address: string
+    nearAccount: Account
+  }
+): Promise<{symbol: string, decimals: number}> {
+  const metadata = await nearAccount.viewFunction(
+    nep141Address,
+    'ft_metadata'
+  )
+  return metadata
+}
+
+export async function getBalance (
+  { nep141Address, owner, nearAccount }: {
+    nep141Address: string
+    owner: string
+    nearAccount: Account
+  }
+): Promise<string> {
+  const balanceAsString = await nearAccount.viewFunction(
+    nep141Address,
+    'ft_balance_of',
+    { account_id: owner }
+  )
+  return balanceAsString
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,6 +1059,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@near-eth/aurora-nep141@workspace:packages/aurora-nep141":
+  version: 0.0.0-use.local
+  resolution: "@near-eth/aurora-nep141@workspace:packages/aurora-nep141"
+  dependencies:
+    "@commitlint/cli": "*"
+    "@commitlint/config-conventional": "*"
+    "@commitlint/travis-cli": "*"
+    "@near-eth/client": "workspace:*"
+    "@near-eth/utils": "workspace:*"
+    "@types/bn.js": ^5.1.0
+    "@types/bs58": ^4.0.1
+    "@types/node": ^14.14.28
+    "@yarnpkg/pnpify": ^2.4.0
+    bn.js: ^5.1.3
+    bs58: ^4.0.1
+    ethereumjs-util: ^7.0.10
+    ethers: ^5.4.6
+    find-replacement-tx: "workspace:*"
+    near-api-js: "https://github.com/aurora-is-near/near-api-js#b31f9975b29c69e65c6db2feca2183fac400109e"
+    promisfy: ^1.2.0
+    rlp: ^2.2.6
+    typescript: 4.1.5
+  languageName: unknown
+  linkType: soft
+
 "@near-eth/client@workspace:*, @near-eth/client@workspace:packages/client":
   version: 0.0.0-use.local
   resolution: "@near-eth/client@workspace:packages/client"


### PR DESCRIPTION
Add `aurora-nep141` library for the aurora<>near bridge.
Even if aurora<>near transfers are single step, the new integrated bridge will benefit from having this package with the same APIs, checkStatus() and act() as other libraries to handle retry, pending transactions and wallet redirects.