### PR TITLE
fix: Remove signer's provider in checkSync.

### DIFF
--- a/.yarn/versions/eb9fd02e.yml
+++ b/.yarn/versions/eb9fd02e.yml
@@ -1,0 +1,7 @@
+releases:
+  "@near-eth/aurora-erc20": patch
+  "@near-eth/aurora-ether": patch
+  "@near-eth/near-ether": patch
+  "@near-eth/nep141-erc20": patch
+  "@near-eth/rainbow": patch
+  rainbow-bridge-client-monorepo: patch

--- a/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.ts
+++ b/packages/aurora-erc20/src/bridged-erc20/sendToEthereum/index.ts
@@ -873,8 +873,16 @@ export async function unlock (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getSignerProvider()
 
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.ethChainId ?? bridgeParams.ethChainId
+  if (ethChainId !== expectedChainId) {
+    throw new Error(
+      `Wrong eth network for checkSync, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
   // Build burn proof
-  transfer = await checkSync(transfer, { ...options, provider })
+  transfer = await checkSync(transfer, options)
   if (transfer.status !== status.ACTION_NEEDED) return transfer
   const proof = transfer.proof
 

--- a/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -825,8 +825,16 @@ export async function unlock (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getSignerProvider()
 
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.ethChainId ?? bridgeParams.ethChainId
+  if (ethChainId !== expectedChainId) {
+    throw new Error(
+      `Wrong eth network for checkSync, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
   // Build burn proof
-  transfer = await checkSync(transfer, { ...options, provider })
+  transfer = await checkSync(transfer, options)
   if (transfer.status !== status.ACTION_NEEDED) return transfer
   const proof = transfer.proof
 

--- a/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -906,8 +906,16 @@ export async function unlock (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getSignerProvider()
 
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.ethChainId ?? bridgeParams.ethChainId
+  if (ethChainId !== expectedChainId) {
+    throw new Error(
+      `Wrong eth network for checkSync, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
   // Build burn proof
-  transfer = await checkSync(transfer, { ...options, provider })
+  transfer = await checkSync(transfer, options)
   if (transfer.status !== status.ACTION_NEEDED) return transfer
   const proof = transfer.proof
 

--- a/packages/near-ether/src/natural-near/sendToEthereum/index.ts
+++ b/packages/near-ether/src/natural-near/sendToEthereum/index.ts
@@ -893,8 +893,16 @@ export async function mint (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getSignerProvider()
 
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.ethChainId ?? bridgeParams.ethChainId
+  if (ethChainId !== expectedChainId) {
+    throw new Error(
+      `Wrong eth network for checkSync, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
   // Build lock proof
-  transfer = await checkSync(transfer, { ...options, provider })
+  transfer = await checkSync(transfer, options)
   if (transfer.status !== status.ACTION_NEEDED) return transfer
   const proof = transfer.proof
 

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.ts
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.ts
@@ -909,8 +909,16 @@ export async function unlock (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getSignerProvider()
 
+  const ethChainId: number = (await provider.getNetwork()).chainId
+  const expectedChainId: number = options.ethChainId ?? bridgeParams.ethChainId
+  if (ethChainId !== expectedChainId) {
+    throw new Error(
+      `Wrong eth network for checkSync, expected: ${expectedChainId}, got: ${ethChainId}`
+    )
+  }
+
   // Build burn proof
-  transfer = await checkSync(transfer, { ...options, provider })
+  transfer = await checkSync(transfer, options)
   if (transfer.status !== status.ACTION_NEEDED) return transfer
   const proof = transfer.proof
 


### PR DESCRIPTION
The WalletConnect provider has issues with `eth_call`, so don't use it for building a finalization proof in checkSync.