### PR TITLE
feat: Check withdraw abi

### DIFF
--- a/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -812,8 +812,10 @@ export async function unlock (
   // Unlock
   const borshProof = borshifyOutcomeProof(proof)
 
+  const etherCustodianProxyAddress = options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress
+  const etherCustodianAddress = options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress
   const ethTokenLocker = new ethers.Contract(
-    options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress,
+    etherCustodianProxyAddress,
     options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi,
     options.signer ?? provider.getSigner()
   )
@@ -821,9 +823,8 @@ export async function unlock (
   // in case there was a reorg.
   const safeReorgHeight = await provider.getBlockNumber() - 20
 
-  const withdrawAbi = ethTokenLocker.interface.functions.withdraw
   let pendingUnlockTx
-  if (withdrawAbi && withdrawAbi.inputs.length === 3) {
+  if (etherCustodianProxyAddress.toLowerCase() !== etherCustodianAddress.toLowerCase()) {
     pendingUnlockTx = await ethTokenLocker.withdraw(
       borshProof,
       transfer.nearOnEthClientBlockHeight,

--- a/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/aurora-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -820,11 +820,21 @@ export async function unlock (
   // If this tx is dropped and replaced, lower the search boundary
   // in case there was a reorg.
   const safeReorgHeight = await provider.getBlockNumber() - 20
-  const pendingUnlockTx = await ethTokenLocker.withdraw(
-    borshProof,
-    transfer.nearOnEthClientBlockHeight,
-    last(transfer.nearBurnReceiptBlockHeights)
-  )
+
+  const withdrawAbi = ethTokenLocker.interface.functions.withdraw
+  let pendingUnlockTx
+  if (withdrawAbi && withdrawAbi.inputs.length === 3) {
+    pendingUnlockTx = await ethTokenLocker.withdraw(
+      borshProof,
+      transfer.nearOnEthClientBlockHeight,
+      last(transfer.nearBurnReceiptBlockHeights)
+    )
+  } else {
+    pendingUnlockTx = await ethTokenLocker.withdraw(
+      borshProof,
+      transfer.nearOnEthClientBlockHeight
+    )
+  }
   // TODO: Handle erc20Locker.unlockToken when ETH is not the native silo token.
 
   return {

--- a/packages/aurora-ether/src/natural-ether/sendToAurora/index.ts
+++ b/packages/aurora-ether/src/natural-ether/sendToAurora/index.ts
@@ -175,12 +175,20 @@ export async function findAllTransactions (
   options = options ?? {}
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getEthProvider()
-  const etherCustodians: Array<[string, string]> = [
-    [options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress,
-      options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi],
-    [options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress,
-      options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
-  ]
+
+  const etherCustodianProxyAddress = options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress
+  const etherCustodianAddress = options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress
+  let etherCustodians: Array<[string, string]>
+  if (etherCustodianProxyAddress.toLowerCase() !== etherCustodianAddress.toLowerCase()) {
+    etherCustodians = [
+      [etherCustodianProxyAddress, options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi],
+      [etherCustodianAddress, options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
+    ]
+  } else {
+    etherCustodians = [
+      [etherCustodianAddress, options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
+    ]
+  }
   const auroraAddress = options.auroraEvmAccount ?? bridgeParams.auroraEvmAccount as string + ':'
 
   const promises = etherCustodians.map(async ([ethCustodianAddress, ethCustodianAbi]) => {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -498,6 +498,10 @@ setBridgeParams({
   etherCustodianAddress: '0x6BFaD42cFC4EfC96f529D786D643Ff4A8B89FA52',
   // https://github.com/aurora-is-near/rainbow-bridge-frontend/blob/master/abi/etherCustodian.full.abi
   etherCustodianAbi: process.env.etherCustodianAbi,
+  // https://github.com/aurora-is-near/eth-connector/tree/master/eth-custodian
+  etherCustodianProxyAddress: 'TODO',
+  // https://github.com/aurora-is-near/eth-connector/tree/master/eth-custodian
+  etherCustodianProxyAbi: process.env.etherCustodianProxyAbiText,
   auroraEvmAccount: 'aurora',
   auroraRelayerAccount: 'relay.aurora',
   etherExitToEthereumPrecompile: '0xb0bD02F6a392aF548bDf1CfAeE5dFa0EefcC8EaB',
@@ -553,6 +557,10 @@ setBridgeParams({
   etherCustodianAddress: '0x84a82Bb39c83989D5Dc07e1310281923D2544dC2',
   // https://github.com/aurora-is-near/rainbow-bridge-frontend/blob/master/abi/etherCustodian.full.abi
   etherCustodianAbi: process.env.etherCustodianAbi,
+  // https://github.com/aurora-is-near/eth-connector/tree/master/eth-custodian
+  etherCustodianProxyAddress: '0x4C8afA2fD22dB1c6091A96c382e6546529475B5c',
+  // https://github.com/aurora-is-near/eth-connector/tree/master/eth-custodian
+  etherCustodianProxyAbi: process.env.etherCustodianProxyAbiText,
   auroraEvmAccount: 'aurora',
   auroraRelayerAccount: 'relay.aurora',
   etherExitToEthereumPrecompile: '0xb0bD02F6a392aF548bDf1CfAeE5dFa0EefcC8EaB',

--- a/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -815,8 +815,10 @@ export async function unlock (
 
   const borshProof = borshifyOutcomeProof(proof)
 
+  const etherCustodianProxyAddress = options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress
+  const etherCustodianAddress = options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress
   const ethTokenLocker = new ethers.Contract(
-    options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress,
+    etherCustodianProxyAddress,
     options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi,
     options.signer ?? provider.getSigner()
   )
@@ -824,9 +826,8 @@ export async function unlock (
   // in case there was a reorg.
   const safeReorgHeight = await provider.getBlockNumber() - 20
 
-  const withdrawAbi = ethTokenLocker.interface.functions.withdraw
   let pendingUnlockTx
-  if (withdrawAbi && withdrawAbi.inputs.length === 3) {
+  if (etherCustodianProxyAddress.toLowerCase() !== etherCustodianAddress.toLowerCase()) {
     pendingUnlockTx = await ethTokenLocker.withdraw(
       borshProof,
       transfer.nearOnEthClientBlockHeight,

--- a/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
+++ b/packages/near-ether/src/bridged-ether/sendToEthereum/index.ts
@@ -823,11 +823,21 @@ export async function unlock (
   // If this tx is dropped and replaced, lower the search boundary
   // in case there was a reorg.
   const safeReorgHeight = await provider.getBlockNumber() - 20
-  const pendingUnlockTx = await ethTokenLocker.withdraw(
-    borshProof,
-    transfer.nearOnEthClientBlockHeight,
-    last(transfer.burnReceiptBlockHeights)
-  )
+
+  const withdrawAbi = ethTokenLocker.interface.functions.withdraw
+  let pendingUnlockTx
+  if (withdrawAbi && withdrawAbi.inputs.length === 3) {
+    pendingUnlockTx = await ethTokenLocker.withdraw(
+      borshProof,
+      transfer.nearOnEthClientBlockHeight,
+      last(transfer.burnReceiptBlockHeights)
+    )
+  } else {
+    pendingUnlockTx = await ethTokenLocker.withdraw(
+      borshProof,
+      transfer.nearOnEthClientBlockHeight
+    )
+  }
 
   return {
     ...transfer,

--- a/packages/near-ether/src/natural-ether/sendToNear/index.ts
+++ b/packages/near-ether/src/natural-ether/sendToNear/index.ts
@@ -198,12 +198,19 @@ export async function findAllTransactions (
   const bridgeParams = getBridgeParams()
   const provider = options.provider ?? getEthProvider()
 
-  const etherCustodians: Array<[string, string]> = [
-    [options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress,
-      options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi],
-    [options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress,
-      options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
-  ]
+  const etherCustodianProxyAddress = options.etherCustodianProxyAddress ?? bridgeParams.etherCustodianProxyAddress
+  const etherCustodianAddress = options.etherCustodianAddress ?? bridgeParams.etherCustodianAddress
+  let etherCustodians: Array<[string, string]>
+  if (etherCustodianProxyAddress.toLowerCase() !== etherCustodianAddress.toLowerCase()) {
+    etherCustodians = [
+      [etherCustodianProxyAddress, options.etherCustodianProxyAbi ?? bridgeParams.etherCustodianProxyAbi],
+      [etherCustodianAddress, options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
+    ]
+  } else {
+    etherCustodians = [
+      [etherCustodianAddress, options.etherCustodianAbi ?? bridgeParams.etherCustodianAbi]
+    ]
+  }
 
   const promises = etherCustodians.map(async ([ethCustodianAddress, ethCustodianAbi]) => {
     const ethTokenLocker = new ethers.Contract(


### PR DESCRIPTION
Add backward compatibility for eth-conenctor withdraw, so it should works for both Mainnet (without migration) and testnet (with migration)